### PR TITLE
Fixing error in code for fig_24

### DIFF
--- a/notebooks/fig_24_tf_idf_from_scratch.ipynb
+++ b/notebooks/fig_24_tf_idf_from_scratch.ipynb
@@ -284,6 +284,7 @@
    ],
    "source": [
     "# Simple frequency counts of words per document by initializing a dict\n",
+    "import pandas as pd"
     "dict_a = dict.fromkeys(total_corpus, 0)\n",
     "dict_b = dict.fromkeys(total_corpus, 0)\n",
     "\n",
@@ -544,7 +545,6 @@
    "outputs": [],
    "source": [
     "from sklearn.feature_extraction.text import TfidfVectorizer\n",
-    "import pandas as pd\n",
     "\n",
     "corpus = [\n",
     "    \"Hold fast to dreams, for if dreams die, life is a broken-winged bird that cannot fly.\",\n",
@@ -555,7 +555,7 @@
     "\n",
     "vectorizer = TfidfVectorizer()\n",
     "vector = vectorizer.fit_transform(corpus)\n",
-    "dict(zip(vectorizer.get_feature_names_out(), X.toarray()[0]))\n",
+    "dict(zip(vectorizer.get_feature_names_out(), vector.toarray()[0]))\n",
     "\n",
     "tfidf_df = pd.DataFrame(vector.toarray(), index=text_titles, columns=vectorizer.get_feature_names_out())"
    ]
@@ -752,7 +752,7 @@
        "</div>"
       ],
       "text/plain": [
-       "        dreams_langstonhughes  quote_william_blake  00_Document Frequency\n",
+       "        quote_langstonhughes  quote_william_blake  00_Document Frequency\n",
        "bird                 0.172503             0.197242                    2.0\n",
        "broken               0.242447             0.000000                    1.0\n",
        "cannot               0.242447             0.000000                    1.0\n",


### PR DESCRIPTION
The code errors when running it; I suspect because it was run out of order at some point. Two minor fixes to make this work: moving pandas import up, and using `vector` instead of `X` in the vectorizer step.

Not technically a bug, but these out-of also led to the table column headers being inconsistent in the rendered PDF.