### PR TITLE
Fixing broken links to LLM resources

### DIFF
--- a/docs/next.html
+++ b/docs/next.html
@@ -220,10 +220,10 @@
                             <h2> LLMs
                             </h2>
                             <ul class=" list-group">
-                                <li class="list-group-item"><a href="https://arxiv.org/abs/1510.00726s">Understanding
+                                <li class="list-group-item"><a href="https://sebastianraschka.com/blog/2023/llm-reading-list.html">Understanding
                                         Large Language Models -- A Transformative Reading List</a> - Sebastian's whole
                                     site is very worth reading, start with this survey of LLM posts and literature</li>
-                                <li class="list-group-item"><a href="https://arxiv.org/abs/1510.00726s">A
+                                <li class="list-group-item"><a href="https://arxiv.org/abs/1510.00726">A
                                         Primer on Neural Network Models for Natural Language Processing</a> - Good idea
                                     to read everything Yoav has written but this is a great start</li>
                                 <li class="list-group-item"><a href="https://github.com/ray-project/llm-numbers">Figures


### PR DESCRIPTION
Just fixing a couple links to resources about LLMs in the site page. Minor, but these links are super great and I don't want anyone to miss out.

Thank you for this resource and all your work!